### PR TITLE
Add option to use blender-oriented rigs

### DIFF
--- a/plywood-cube/puppetry.py
+++ b/plywood-cube/puppetry.py
@@ -16,6 +16,7 @@ Global = {}
 
 PLYWOOD_CUBE_PUMP = uuid.UUID('acc4ce6d-f50d-417e-b7c6-cc5d6a6b850b')
 
+
 class PuppetrySession:
     def __init__(self):
         self.props = None
@@ -46,7 +47,7 @@ class PuppetrySession:
         if not self.pump:
             return
         data = llbase.llsd.format_notation({"pump": pump, "data": data})
-        data = str(len(data)).encode()+b":"+data
+        data = str(len(data)).encode() + b":" + data
         print(data)
         return self.sock.sendall(data)
     
@@ -54,7 +55,7 @@ class PuppetrySession:
         data = llbase.llsd.parse_notation(data)
         if not self.pump:
             self.pump = data
-            #Disconnect any existing pumps
+            # Disconnect any existing pumps
             self.send(self.pump["data"]["command"], {
                 "op": "stoplisten",
                 "reqid": -1,
@@ -62,7 +63,7 @@ class PuppetrySession:
                 "listener": PLYWOOD_CUBE_PUMP
             })
             
-            #Connect the pump
+            # Connect the pump
             self.send(self.pump["data"]["command"], {
                 "op": "listen",
                 "reqid": -1,
@@ -101,7 +102,7 @@ class PuppetrySession:
                 continue
             
             if not (self.props.Transmit[bn].position \
-             or self.props.Transmit[bn].rotation):
+                    or self.props.Transmit[bn].rotation):
                 continue
             
             db = arm.data.bones[bn]
@@ -145,7 +146,7 @@ class PuppetrySession:
                         shouldUpdate = True
                     elif self.last[bn][check] != updates[bn][check]:
                         shouldUpdate = True
-                        
+                
                 for check in self.last[bn].keys():
                     if check not in updates[bn]:
                         shouldUpdate = True
@@ -158,7 +159,7 @@ class PuppetrySession:
                 "command": "set",
                 "reply": None,
                 "data": {
-                    #Could also use "joint_state" instead of "j"
+                    # Could also use "joint_state" instead of "j"
                     "j": updates
                 }
             })
@@ -207,19 +208,22 @@ class PuppetrySession:
         self.shouldClose = True
         self.disconnect()
 
-#==============================================================================
+
+# ==============================================================================
 # Blender Operator class
-#==============================================================================
-#Custom types
+# ==============================================================================
+# Custom types
 class PuppetryTransmitList(bpy.types.PropertyGroup):
     position: bpy.props.IntProperty(name="A")
     rotation: bpy.props.IntProperty(name="B")
     group: bpy.props.StringProperty()
 
+
 class StringArrayProperty(bpy.types.PropertyGroup):
     name: bpy.props.StringProperty()
 
-#Connect submenu
+
+# Connect submenu
 class VIEW3D_OT_puppetry_connect(bpy.types.Operator):
     bl_idname = "puppetry.connect"
     bl_label = 'Connect to puppetry server'
@@ -240,13 +244,14 @@ class VIEW3D_OT_puppetry_connect(bpy.types.Operator):
 def add_items_from_collection_callback(self, context):
     return [(v.name, v.name, '') for v in bpy.context.scene.puppetry.TransmitGroups]
 
+
 class PuppetryProperties(bpy.types.PropertyGroup):
     Host: bpy.props.StringProperty(
         name="Host",
         default="127.0.0.1",
         maxlen=1024,
     )
-
+    
     Port: bpy.props.IntProperty(
         name="Port",
         default=5000,
@@ -256,7 +261,7 @@ class PuppetryProperties(bpy.types.PropertyGroup):
     
     Armatures: bpy.props.CollectionProperty(type=StringArrayProperty)
     
-    Target: bpy.props.StringProperty(name = "Target")
+    Target: bpy.props.StringProperty(name="Target")
     
     Transmit: bpy.props.CollectionProperty(type=PuppetryTransmitList)
     Transmit_index: bpy.props.IntProperty()
@@ -264,11 +269,12 @@ class PuppetryProperties(bpy.types.PropertyGroup):
     TransmitGroupEnum: bpy.props.EnumProperty(items=add_items_from_collection_callback)
     
     UpdateTime: bpy.props.FloatProperty(
-        name = "Update rate",
-        default = 0.1,
-        min = 0.05,
-        max = 5
+        name="Update rate",
+        default=0.1,
+        min=0.05,
+        max=5
     )
+
 
 class VIEW3D_PT_puppetry_connect(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
@@ -283,24 +289,26 @@ class VIEW3D_PT_puppetry_connect(bpy.types.Panel):
         props = scene.puppetry
         
         Session.setProps(props)
-
+        
         layout.prop(props, "Host")
         layout.prop(props, "Port")
         layout.separator()
         if Session.connected:
-            layout.operator('puppetry.connect', text = 'Disconnect')
+            layout.operator('puppetry.connect', text='Disconnect')
         else:
-            layout.operator('puppetry.connect', text = 'Connect')
+            layout.operator('puppetry.connect', text='Connect')
 
-#Armature submenu
+
+# Armature submenu
 @bpy.app.handlers.persistent
 def findArmatures(self):
     findArmaturesReal()
 
+
 def findArmaturesReal():
     context = bpy.context
     props = bpy.context.scene.puppetry
-
+    
     props.Armatures.clear()
     
     for o in bpy.data.objects:
@@ -311,13 +319,14 @@ def findArmaturesReal():
     if len(props.Armatures) == 1 and props.Target == "":
         props.Target = props.Armatures[0].name
 
+
 class VIEW3D_OT_puppetry_skeleton_action(bpy.types.Operator):
     bl_idname = 'puppetry.skeletonedit'
     bl_label = ''
     
     action: bpy.props.IntProperty(
-        name = 'action',
-        default = -1
+        name='action',
+        default=-1
     )
     
     def execute(self, context):
@@ -332,9 +341,10 @@ class VIEW3D_OT_puppetry_skeleton_action(bpy.types.Operator):
                     "reply": None
                 })
         else:
-            #Reset skeleton?
+            # Reset skeleton?
             pass
         return {'FINISHED'}
+
 
 class VIEW3D_PT_puppetry_armature(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
@@ -359,28 +369,28 @@ class VIEW3D_PT_puppetry_armature(bpy.types.Panel):
         btn = row.operator("puppetry.skeletonedit", text="Reset Skeleton")
         btn.action = 1
         """
-        
 
-#Transmit submenu
+
+# Transmit submenu
 class VIEW3D_OT_puppetry_transmit_toggle(bpy.types.Operator):
     bl_idname = 'puppetry.transmittoggle'
     bl_label = ''
     
     target: bpy.props.StringProperty(
-        name = 'target'
+        name='target'
     )
     
     property: bpy.props.StringProperty(
-        name = 'property'
+        name='property'
     )
     
     group: bpy.props.StringProperty(
-        name = 'group'
+        name='group'
     )
     
     value: bpy.props.IntProperty(
-        name = 'value',
-        default = -1
+        name='value',
+        default=-1
     )
     
     def match(self, prop):
@@ -405,6 +415,7 @@ class VIEW3D_OT_puppetry_transmit_toggle(bpy.types.Operator):
                     setattr(p, self.property, bool(self.value))
         return {'FINISHED'}
 
+
 class VIEW3D_UL_puppetry_transmit(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
@@ -414,19 +425,20 @@ class VIEW3D_UL_puppetry_transmit(bpy.types.UIList):
             split2 = layout.row()
             split2.alignment = "RIGHT"
             
-            btn = split2.operator("puppetry.transmittoggle", icon="OBJECT_ORIGIN" if item.position else "DOT", emboss = False)
+            btn = split2.operator("puppetry.transmittoggle", icon="OBJECT_ORIGIN" if item.position else "DOT",
+                                  emboss=False)
             btn.target = item.name
             btn.property = "position"
-            btn = split2.operator("puppetry.transmittoggle", icon="ORIENTATION_GIMBAL" if item.rotation else "DOT", emboss = False)
+            btn = split2.operator("puppetry.transmittoggle", icon="ORIENTATION_GIMBAL" if item.rotation else "DOT",
+                                  emboss=False)
             btn.target = item.name
             btn.property = "rotation"
-            
     
     def draw_filter(self, context, layout):
         scene = context.scene
         props = scene.puppetry
         row = layout.row()
-        row.prop(props, "TransmitGroupEnum", text = "")
+        row.prop(props, "TransmitGroupEnum", text="")
     
     def filter_items(self, context, data, propname):
         filtered = []
@@ -439,6 +451,7 @@ class VIEW3D_UL_puppetry_transmit(bpy.types.UIList):
                 filtered.append(~self.bitflag_filter_item)
         return filtered, ordered
 
+
 class VIEW3D_PT_puppetry_transmit(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
@@ -449,7 +462,7 @@ class VIEW3D_PT_puppetry_transmit(bpy.types.Panel):
         layout = self.layout
         scene = context.scene
         props = scene.puppetry
-
+        
         row = layout.row()
         row.template_list(
             "VIEW3D_UL_puppetry_transmit", "custom_def_list",
@@ -475,7 +488,6 @@ class VIEW3D_PT_puppetry_transmit(bpy.types.Panel):
         
         btn = row.operator("puppetry.transmittoggle", text="Selected")
         
-        
         row = layout.row()
         row.label(text="Disable:", icon="OBJECT_ORIGIN")
         
@@ -492,7 +504,6 @@ class VIEW3D_PT_puppetry_transmit(bpy.types.Panel):
         btn.value = 0
         
         btn = row.operator("puppetry.transmittoggle", text="Selected")
-        
         
         row = layout.row()
         row.label(text="Enable:", icon="ORIENTATION_GIMBAL")
@@ -527,6 +538,7 @@ class VIEW3D_PT_puppetry_transmit(bpy.types.Panel):
         
         btn = row.operator("puppetry.transmittoggle", text="Selected")
 
+
 def populateBoneList():
     transmit = bpy.context.scene.puppetry.Transmit
     groups = bpy.context.scene.puppetry.TransmitGroups
@@ -544,7 +556,8 @@ def populateBoneList():
         b.name = bone["name"]
         b.group = bone["group"]
 
-#Registration
+
+# Registration
 
 module_classes = (
     VIEW3D_OT_puppetry_transmit_toggle,
@@ -559,10 +572,11 @@ module_classes = (
     VIEW3D_PT_puppetry_transmit
 )
 
+
 def register():
     for cls in module_classes:
         bpy.utils.register_class(cls)
-        
+    
     bpy.types.Scene.puppetry = bpy.props.PointerProperty(type=PuppetryProperties)
     
     Global["Session"] = PuppetrySession()
@@ -582,4 +596,3 @@ def unregister():
     
     Session.close()
     del Global["Session"]
-    

--- a/plywood-cube/puppetry.py
+++ b/plywood-cube/puppetry.py
@@ -157,7 +157,7 @@ class PuppetrySession:
             self.send("puppetry", {
                 "command": "set",
                 "reply": None,
-                "set": {
+                "data": {
                     #Could also use "joint_state" instead of "j"
                     "j": updates
                 }


### PR DESCRIPTION
I added an option to use armatures oriented the standard blender way, with -Y axis facing forward:
![HJob98onpx](https://user-images.githubusercontent.com/140755/215241668-99860d44-fcee-4276-8f3b-b4c6f2d8dbb4.png)

I also auto-formatted the whitespace because my usual editor keeps wanting to do that